### PR TITLE
Add a truncate option to the pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For simple text lists:
 With truncate:
 
 ```html
-"{{ list | oxford:'and' : {trial: '...', wordCount: 5}}}"
+"{{ list | oxford:'and' : {trail: '...', wordCount: 5}}}"
 ```
 
 ### ...as a component

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ For simple text lists:
 "{{ list | oxford:'and' }}"
 ```
 
+With truncate:
+
+```html
+"{{ list | oxford:'and' : {trial: '...', wordCount: 5}}}"
+```
+
 ### ...as a component
 
 For HTML, links, style, etc:

--- a/projects/demo/src/app/app.component.html
+++ b/projects/demo/src/app/app.component.html
@@ -13,6 +13,16 @@ Output:
   <li *ngFor="let list of lists">{{ list.length }}: "{{ list | oxford:'and' }}"</li>
 </ul>
 
+Truncate a list:
+<pre>
+  "{{ '{{' }} list | oxford: 'and' : {{ '{' }} trail: 'etc', wordCount: 5 {{ '}' }} }}"
+</pre>
+
+Output:
+<div>
+  {{ longList | oxford : 'and' : {trail: 'etc', wordCount: 5} }}
+</div>
+
 <h2>Component</h2>
 Use:
 <pre>

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -15,4 +15,6 @@ export class AppComponent {
     ['rabbit', 'cat', 'dog'],
     ['rabbit', 'cat', 'dog', 'duck'],
   ];
+
+  longList = ['rabbit', 'cat', 'dog', 'duck', 'kangaroo', 'bear', 'wolf', 'cow', 'snake'];
 }

--- a/projects/ngx-oxford/src/lib/oxford.pipe.spec.ts
+++ b/projects/ngx-oxford/src/lib/oxford.pipe.spec.ts
@@ -63,6 +63,6 @@ describe('OxfordPipe', () => {
         'and',
         {trail: 'etc', maxWords: 12}
       )
-    ).toBe('orange, apple, mango, banana, pineapple');
+    ).toBe('orange, apple, mango, banana, and pineapple');
   });
 });

--- a/projects/ngx-oxford/src/lib/oxford.pipe.spec.ts
+++ b/projects/ngx-oxford/src/lib/oxford.pipe.spec.ts
@@ -52,12 +52,17 @@ describe('OxfordPipe', () => {
   });
 
   it('should truncate a list with specific conjunction', () => {
-    expect(pipe.transform(['orange', 'apple', 'mango', 'banana', 'pineapple'], 'and', {trail: 'etc', wordCount: 3}))
+    expect(pipe.transform(['orange', 'apple', 'mango', 'banana', 'pineapple'], 'and', {trail: 'etc', maxWords: 3}))
           .toBe('orange, apple, mango, etc');
   });
 
-  it('should throw if truncate word count is larger that the array length', () => {
-    expect(() => pipe.transform(['orange', 'apple', 'mango', 'banana', 'pineapple'], 'and', {trail: 'etc', wordCount: 12}))
-          .toThrowError(/larger than/);
+  it('should proceed as usual if truncate word count is larger that the array length', () => {
+    expect(
+      pipe.transform(
+        ['orange', 'apple', 'mango', 'banana', 'pineapple'],
+        'and',
+        {trail: 'etc', maxWords: 12}
+      )
+    ).toBe('orange, apple, mango, banana, pineapple, etc');
   });
 });

--- a/projects/ngx-oxford/src/lib/oxford.pipe.spec.ts
+++ b/projects/ngx-oxford/src/lib/oxford.pipe.spec.ts
@@ -63,6 +63,6 @@ describe('OxfordPipe', () => {
         'and',
         {trail: 'etc', maxWords: 12}
       )
-    ).toBe('orange, apple, mango, banana, pineapple, etc');
+    ).toBe('orange, apple, mango, banana, pineapple');
   });
 });

--- a/projects/ngx-oxford/src/lib/oxford.pipe.spec.ts
+++ b/projects/ngx-oxford/src/lib/oxford.pipe.spec.ts
@@ -50,4 +50,14 @@ describe('OxfordPipe', () => {
     expect(() => pipe.transform(['foo'], '')).toThrowError(/is not a word/);
     expect(() => pipe.transform(['foo'], null)).toThrowError(/is not a word/);
   });
+
+  it('should truncate a list with specific conjunction', () => {
+    expect(pipe.transform(['orange', 'apple', 'mango', 'banana', 'pineapple'], 'and', {trail: 'etc', wordCount: 3}))
+          .toBe('orange, apple, mango, etc');
+  });
+
+  it('should throw if truncate word count is larger that the array length', () => {
+    expect(() => pipe.transform(['orange', 'apple', 'mango', 'banana', 'pineapple'], 'and', {trail: 'etc', wordCount: 12}))
+          .toThrowError(/larger than/);
+  });
 });

--- a/projects/ngx-oxford/src/lib/oxford.pipe.ts
+++ b/projects/ngx-oxford/src/lib/oxford.pipe.ts
@@ -30,9 +30,6 @@ export class OxfordPipe implements PipeTransform {
     let trimmedValues = values.map(OxfordPipe.trim);
 
     if (truncate) {
-      if (truncate.wordCount > values.length) {
-        throw new RangeError('The truncated word count is larger than the amount of words');
-      }
       trimmedValues = trimmedValues.slice(0, truncate.wordCount);
     }
 

--- a/projects/ngx-oxford/src/lib/oxford.pipe.ts
+++ b/projects/ngx-oxford/src/lib/oxford.pipe.ts
@@ -50,7 +50,7 @@ export class OxfordPipe implements PipeTransform {
         trimmedValues[trimmedValues.length - 1],
       )}`;
     } else {
-      result += `${trimmedValues[trimmedValues.length - 1]}, ${truncate.trail || '&#x2026;'}`;
+      result += `${trimmedValues[trimmedValues.length - 1]}${truncate.maxWords < values.length ? `, ${truncate.trail || '&#x2026;'}` : ''}`;
     }
 
     return result;

--- a/projects/ngx-oxford/src/lib/oxford.pipe.ts
+++ b/projects/ngx-oxford/src/lib/oxford.pipe.ts
@@ -1,8 +1,8 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 interface OxfordOptions {
-  trail: string;
-  wordCount: number;
+  trail?: string;
+  maxWords: number;
 }
 
 @Pipe({
@@ -30,7 +30,7 @@ export class OxfordPipe implements PipeTransform {
     let trimmedValues = values.map(OxfordPipe.trim);
 
     if (truncate) {
-      trimmedValues = trimmedValues.slice(0, truncate.wordCount);
+      trimmedValues = trimmedValues.slice(0, truncate.maxWords);
     }
 
     if (trimmedValues.length < 2) {
@@ -50,7 +50,7 @@ export class OxfordPipe implements PipeTransform {
         trimmedValues[trimmedValues.length - 1],
       )}`;
     } else {
-      result += `${trimmedValues[trimmedValues.length - 1]}, ${truncate.trail}`;
+      result += `${trimmedValues[trimmedValues.length - 1]}, ${truncate.trail || '&#x2026;'}`;
     }
 
     return result;

--- a/projects/ngx-oxford/src/lib/oxford.pipe.ts
+++ b/projects/ngx-oxford/src/lib/oxford.pipe.ts
@@ -1,5 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
+interface TruncateOptions {
+  trail: string;
+  wordCount: number;
+}
+
 @Pipe({
   name: 'oxford',
 })
@@ -8,7 +13,12 @@ export class OxfordPipe implements PipeTransform {
     return ('' + value).trim();
   }
 
-  transform(values: string[], conjunction = 'and', ...args: any[]): any {
+  transform(
+    values: string[],
+    conjunction = 'and',
+    truncate: TruncateOptions = null,
+    ...args: any[]
+  ): any {
     if (values === null || values === undefined) {
       throw new TypeError(`Wrong value for Oxford Pipe provided: ${values} is not an array`);
     }
@@ -17,7 +27,14 @@ export class OxfordPipe implements PipeTransform {
       throw new TypeError(`Wrong conjunction for Oxford Pipe provided: ${conjunction} is not a word`);
     }
 
-    const trimmedValues = values.map(OxfordPipe.trim);
+    let trimmedValues = values.map(OxfordPipe.trim);
+
+    if (truncate) {
+      if (truncate.wordCount > values.length) {
+        throw new RangeError('The truncated word count is larger than the amount of words');
+      }
+      trimmedValues = trimmedValues.slice(0, truncate.wordCount);
+    }
 
     if (trimmedValues.length < 2) {
       return trimmedValues[0] || '';
@@ -31,9 +48,14 @@ export class OxfordPipe implements PipeTransform {
     for (let i = 0; i < trimmedValues.length - 1; i++) {
       result += `${OxfordPipe.trim(trimmedValues[i])}, `;
     }
-    result += `${OxfordPipe.trim(conjunction)} ${OxfordPipe.trim(
-      trimmedValues[trimmedValues.length - 1],
-    )}`;
+    if (!truncate) {
+      result += `${OxfordPipe.trim(conjunction)} ${OxfordPipe.trim(
+        trimmedValues[trimmedValues.length - 1],
+      )}`;
+    } else {
+      result += `${trimmedValues[trimmedValues.length - 1]}, ${truncate.trail}`;
+    }
+
     return result;
   }
 }

--- a/projects/ngx-oxford/src/lib/oxford.pipe.ts
+++ b/projects/ngx-oxford/src/lib/oxford.pipe.ts
@@ -49,8 +49,10 @@ export class OxfordPipe implements PipeTransform {
       result += `${OxfordPipe.trim(conjunction)} ${OxfordPipe.trim(
         trimmedValues[trimmedValues.length - 1],
       )}`;
+    } else if (truncate.maxWords > values.length) {
+      result += `${OxfordPipe.trim(conjunction)} ${trimmedValues[trimmedValues.length - 1]}`;
     } else {
-      result += `${trimmedValues[trimmedValues.length - 1]}${truncate.maxWords < values.length ? `, ${truncate.trail || '&#x2026;'}` : ''}`;
+      result += `${trimmedValues[trimmedValues.length - 1]}, ${truncate.trail || '&#x2026;'}`;
     }
 
     return result;

--- a/projects/ngx-oxford/src/lib/oxford.pipe.ts
+++ b/projects/ngx-oxford/src/lib/oxford.pipe.ts
@@ -1,6 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-interface TruncateOptions {
+interface OxfordOptions {
   trail: string;
   wordCount: number;
 }
@@ -16,7 +16,7 @@ export class OxfordPipe implements PipeTransform {
   transform(
     values: string[],
     conjunction = 'and',
-    truncate: TruncateOptions = null,
+    truncate: OxfordOptions = null,
     ...args: any[]
   ): any {
     if (values === null || values === undefined) {


### PR DESCRIPTION
As promised, this PR adds a new argument to the `Oxford pipe`. allowing users to trim long lists with specific trail symbols. This PR:

- Adds the parameter
- Updates the unit tests
- Updates the showcase demo app to include a truncate option
- Updates the README file

